### PR TITLE
Update for Beemo v0.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	BEEMO_CONFIG=config.yml beemo
+
+serve:
+	python -m http.server -d www 8000 &

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,6 @@
+posts_dir: content/posts
+pages_dir: content/pages
+static_dir: static
+templates_dir: templates
+blog_root: blog
+output_dir: www

--- a/content/pages/404/meta.yml
+++ b/content/pages/404/meta.yml
@@ -1,4 +1,3 @@
 title: 404 - Not found
-html_title: 404 - Not found
 slug: "404"
 description: The requested page does not exist

--- a/content/pages/about/meta.yml
+++ b/content/pages/about/meta.yml
@@ -1,4 +1,3 @@
 title: About Me
-html_title: Ben Nuttall - About me
 slug: about
 description: About Ben Nuttall, software engineer at the BBC. Former Raspberry Pi Community Manager. Creator of GPIO Zero and piwheels.

--- a/content/pages/home/meta.yml
+++ b/content/pages/home/meta.yml
@@ -1,3 +1,2 @@
 title: Ben Nuttall
-html_title: Ben Nuttall - Software engineer
 description: Software engineer at the BBC. Former Raspberry Pi Community Manager. Creator of GPIO Zero and piwheels.

--- a/content/pages/projects/meta.yml
+++ b/content/pages/projects/meta.yml
@@ -1,4 +1,3 @@
 title: Projects
-html_title: Ben Nuttall - Projects
 slug: projects
 description: Ben Nuttall's open source software projects

--- a/content/pages/talks/meta.yml
+++ b/content/pages/talks/meta.yml
@@ -1,5 +1,4 @@
 title: Talks
-html_title: Ben Nuttall - Talks
 slug: talks
 description: Conference talks given by software engineer Ben Nuttall
 full_width: true

--- a/static/styles.css
+++ b/static/styles.css
@@ -206,5 +206,33 @@ figcaption a, figcaption a:hover {
 }
 
 figure {
-  margin: 0 0 20px 0;
+  margin: 20px 0;
+  text-align: center;
+}
+
+.wp-block-image {
+  display: table;
+  margin: 20px auto;
+}
+
+.wp-block-image img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.wp-block-image figcaption {
+  display: table-caption;
+  caption-side: bottom;
+  padding: 5px 2px;
+  background: #159ed5;
+  text-align: center;
+  font-size: 14px;
+  border: 0;
+  border-top: 0;
+  color: white;
+}
+
+figcaption a:link, figcaption a:hover {
+  color: white;
 }

--- a/templates/archive.pt
+++ b/templates/archive.pt
@@ -1,14 +1,14 @@
 <div metal:use-macro="layout">
   <div metal:fill-slot="head" tal:omit-tag="1">
-    <meta name="description" content="${description}" />
+    <meta name="description" content="Ben Nuttall's blog archive" />
     <meta property="og:url" content="https://bennuttall.com/${link}/" />
-    <meta property="og:title" content="${html_title}" />
-    <meta property="og:description" content="${description}" />
-    <meta name="twitter:title" content="${html_title}" />
-    <meta name="twitter:description" content="${description}" />
+    <meta property="og:title" content="${title}" />
+    <meta property="og:description" content="Ben Nuttall's blog archive" />
+    <meta name="twitter:title" content="${title}" />
+    <meta name="twitter:description" content="Ben Nuttall's blog archive" />
   </div>
 
-  <div metal:fill-slot="title" tal:omit-tag="1">${html_title}</div>
+  <div metal:fill-slot="title" tal:omit-tag="1">${title}</div>
 
   <section metal:fill-slot="content">
     <div>

--- a/templates/home.pt
+++ b/templates/home.pt
@@ -1,14 +1,14 @@
 <div metal:use-macro="layout">
   <div metal:fill-slot="head" tal:omit-tag="1">
-    <meta name="description" content="${page.description}" />
-    <meta property="og:url" content="https://bennuttall.com/blog/archive/" />
-    <meta property="og:title" content="${page.html_title}" />
-    <meta property="og:description" content="${page.description}" />
-    <meta name="twitter:title" content="${page.html_title}" />
-    <meta name="twitter:description" content="${page.description}" />
+    <meta name="description" content="The homepage of software engineer Ben Nuttall" />
+    <meta property="og:url" content="https://bennuttall.com/" />
+    <meta property="og:title" content="${page.title}" />
+    <meta property="og:description" content="The homepage of software engineer Ben Nuttall" />
+    <meta name="twitter:title" content="${page.title}" />
+    <meta name="twitter:description" content="The homepage of software engineer Ben Nuttall" />
   </div>
 
-  <div metal:fill-slot="title" tal:omit-tag="1">${page.html_title}</div>
+  <div metal:fill-slot="title" tal:omit-tag="1">software engineer</div>
 
   <section metal:fill-slot="content">
     <div>

--- a/templates/layout.pt
+++ b/templates/layout.pt
@@ -1,7 +1,7 @@
 <foo tal:omit-tag="1" metal:define-macro="layout"><!doctype html>
 <html class="no-js" lang="en" dir="ltr">
   <head>
-    <title><span metal:define-slot="title" /></title>
+    <title>Ben Nuttall - <span metal:define-slot="title" /></title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/foundation-float.min.css">

--- a/templates/page.pt
+++ b/templates/page.pt
@@ -8,7 +8,7 @@
     <meta name="twitter:description" content="${page.description}" />
   </div>
 
-  <div metal:fill-slot="title" tal:omit-tag="1">${page.html_title}</div>
+  <div metal:fill-slot="title" tal:omit-tag="1">${page.title}</div>
 
   <section metal:fill-slot="content">
     <div>

--- a/templates/post.pt
+++ b/templates/post.pt
@@ -8,7 +8,7 @@
     <meta name="twitter:description" content="${post.excerpt}" />
   </div>
 
-  <div metal:fill-slot="title" tal:omit-tag="1" tal:content="structure post.html_title"></div>
+  <div metal:fill-slot="title" tal:omit-tag="1" tal:content="structure post.title"></div>
 
   <section metal:fill-slot="content">
     <div>

--- a/templates/posts.pt
+++ b/templates/posts.pt
@@ -1,14 +1,14 @@
 <div metal:use-macro="layout">
   <div metal:fill-slot="head" tal:omit-tag="1">
-    <meta name="description" content="${description}" />
+    <meta name="description" content="Ben Nuttall blog - ${title}" />
     <meta property="og:url" content="https://bennuttall.com/${link}" />
-    <meta property="og:title" content="${description}" />
-    <meta property="og:description" content="${description}" />
-    <meta name="twitter:title" content="${description}" />
-    <meta name="twitter:description" content="${description}" />
+    <meta property="og:title" content="Ben Nuttall blog - ${title}" />
+    <meta property="og:description" content="Ben Nuttall blog - ${title}" />
+    <meta name="twitter:title" content="Ben Nuttall blog - ${title}" />
+    <meta name="twitter:description" content="Ben Nuttall blog - ${title}" />
   </div>
 
-  <div metal:fill-slot="title" tal:omit-tag="1">${html_title}</div>
+  <div metal:fill-slot="title" tal:omit-tag="1">${title}</div>
 
   <section metal:fill-slot="content">
     <div class="row">

--- a/templates/tags.pt
+++ b/templates/tags.pt
@@ -2,19 +2,19 @@
   <div metal:fill-slot="head" tal:omit-tag="1">
     <meta name="description" content="Tags index for Ben Nuttall's blog posts" />
     <meta property="og:url" content="https://bennuttall.com/blog/tags/" />
-    <meta property="og:title" content="${html_title}" />
-    <meta property="og:description" content="${description}" />
-    <meta name="twitter:title" content="${html_title}" />
-    <meta name="twitter:description" content="${description}" />
+    <meta property="og:title" content="Tags" />
+    <meta property="og:description" content="Tags index for Ben Nuttall's blog posts" />
+    <meta name="twitter:title" content="Tags" />
+    <meta name="twitter:description" content="Tags index for Ben Nuttall's blog posts" />
   </div>
 
-  <div metal:fill-slot="title" tal:omit-tag="1">${html_title}</div>
+  <div metal:fill-slot="title" tal:omit-tag="1">Tags</div>
 
   <section metal:fill-slot="content">
     <div>
       <div class="row">
         <div class="small-12 columns">
-          <h1>${title}</h1>
+          <h1>Tags</h1>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
Update for Beemo v0.2.0 - config file, no `meta_title` and `meta_description` fields in page yaml, set titles and description in templates instead